### PR TITLE
Ubuntu 16.04 is being deprecated

### DIFF
--- a/workflows/release-multi-os.yml
+++ b/workflows/release-multi-os.yml
@@ -9,7 +9,7 @@ name: Release Multi Platform
 jobs:
   build-linux:
     name: Create Release and Upload Asset Ubuntu
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.6]

--- a/workflows/release-ubuntu.yml
+++ b/workflows/release-ubuntu.yml
@@ -9,7 +9,7 @@ name: Release Ubuntu
 jobs:
   build:
     name: Upload Release Asset
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.6]


### PR DESCRIPTION
As stated in the [Official Github Docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) Ubuntu 16.04 is being deprecated.

The oldest supported Ubuntu version has become 18.04, release workflows have been modified accordingly.